### PR TITLE
Ensure linear regression scene renders final frame

### DIFF
--- a/manim/linear_regression_scene.py
+++ b/manim/linear_regression_scene.py
@@ -32,3 +32,6 @@ class LinearRegressionExample(Scene):
 
         # Add to scene
         self.add(title, axes, x_label, y_label, regression_line, equation, *dots)
+
+        # Hold on final frame
+        self.wait()


### PR DESCRIPTION
## Summary
- call `self.wait()` in `LinearRegressionExample` to display final frame

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: cannot load such file -- jekyll)*
- `python -m py_compile manim/linear_regression_scene.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ef8927548323b96ea2a466a81de3