### PR TITLE
Fix MathJax overflow (#7)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,9 @@
             tex: {
                 inlineMath: [['$', '$'], ['\\(', '\\)']],
                 displayMath: [['$$', '$$'], ['\\[', '\\]']]
+            },
+            chtml: {
+                linebreaks: { automatic: true, width: 'container' }
             }
         };
     </script>

--- a/static/post.css
+++ b/static/post.css
@@ -80,6 +80,31 @@
     padding: 0.1px 2rem 2rem;
 }
 
+/* MathJax Responsive Handling (scoped) */
+.post-content mjx-container[jax="CHTML"] {
+    max-width: 100% !important;
+}
+
+.post-content mjx-container[jax="CHTML"][display="true"] {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem;
+    margin: 1rem 0;
+}
+
+/* Ensure long inline expressions wrap instead of overflowing */
+.post-content mjx-container[jax="CHTML"][display="false"] mjx-math {
+    white-space: normal !important;
+}
+
+/* Prevent very large math from exceeding container on small screens */
+@media (max-width: 768px) {
+    .post-content mjx-container[jax="CHTML"][display="true"] {
+        font-size: 0.95rem;
+    }
+}
+
 /* Markdown Content Styles */
 .markdown {
     color: var(--dark-color);

--- a/static/styles.css
+++ b/static/styles.css
@@ -23,10 +23,37 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     line-height: 1.6;
     color: var(--dark-color);
-    overflow-x: hidden;
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+}
+
+/* MathJax Global Responsive Adjustments */
+mjx-container[jax="CHTML"][display="true"] {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100% !important;
+}
+
+mjx-container[jax="CHTML"][display="false"] {
+    white-space: normal;
+}
+
+/* Force math content to wrap within container before causing viewport overflow */
+mjx-container[jax="CHTML"] mjx-math {
+    white-space: normal !important;
+}
+
+/* If MathJax sets a large min-width internally, constrain to container */
+mjx-container[jax="CHTML"] {
+    max-width: 100% !important;
+    width: 100% !important;
+}
+
+/* Provide internal scrolling only if still wider (safety) */
+mjx-container[jax="CHTML"] mjx-assistive-mml, /* keep accessible math hidden semantics unaffected */
+mjx-container[jax="CHTML"][display="true"] mjx-math {
+    overflow-x: visible;
 }
 
 main {


### PR DESCRIPTION
This pull request improves the responsive rendering of MathJax math content throughout the site, ensuring that mathematical expressions display correctly on all screen sizes and do not overflow their containers. The changes include both configuration updates and new CSS rules for better layout and usability.

**MathJax configuration and responsive rendering:**

* Updated the MathJax configuration in `_layouts/default.html` to enable automatic line breaking and set the linebreak width to match the container, improving the handling of long equations.

**Global and post-specific CSS for MathJax:**

* Added global CSS in `static/styles.css` to ensure that MathJax's CommonHTML output (`mjx-container[jax="CHTML"]`) is constrained to the container width, allows horizontal scrolling for block math, and forces math content to wrap to prevent viewport overflow.
* Added scoped CSS in `static/post.css` to further refine MathJax rendering within posts, including responsive font sizing for block math on small screens, proper wrapping for long inline expressions, and improved spacing and scrolling for displayed equations.

Closes #7 