### PR TITLE
Add brand-specific hover effects for social links in the About section

### DIFF
--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -35,7 +35,13 @@
 .social-links { display:flex; gap:1rem; position:relative; pointer-events:auto; }
 .social-links a { cursor:pointer; }
 .social-links a { color:var(--color-text-faint); font-size:1.5rem; transition:color .3s ease, transform .3s ease, text-shadow .3s ease; }
-.social-links a:hover { transform:translateY(-3px) scale(1.07); color:var(--primary-color); text-shadow:0 4px 18px rgba(59,130,246,0.5); }
+.social-links a:hover { transform:translateY(-3px) scale(1.07); }
+/* Brand-specific hover colors */
+.social-links a.social-github:hover { color:#ffffff; text-shadow:0 4px 18px rgba(255,255,255,0.45); }
+.social-links a.social-email:hover { color:#5865F2; text-shadow:0 4px 18px rgba(234,67,53,0.55); }
+.social-links a.social-youtube:hover { color:#ff0000; text-shadow:0 4px 20px rgba(255,0,0,0.55); }
+.social-links a.social-discord:hover { color:#5865F2; text-shadow:0 4px 18px rgba(88,101,242,0.55); }
+.social-links a.social-chess:hover { color:#7fa650; text-shadow:0 4px 18px rgba(127,166,80,0.55); } /* chess.com green */
 .now-column { flex:1; }
 .now-items { display:flex; flex-direction:column; gap:1.5rem; }
 .now-item { display:flex; align-items:flex-start; gap:1rem; }

--- a/index.html
+++ b/index.html
@@ -52,14 +52,20 @@ description: Personal website of Taemin Park, showcasing his projects, blog post
                                 <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/c/c-original.svg" alt="C" title="C">
                             </div>
                             <div class="social-links">
-                                <a href="https://github.com/taemincode" target="_blank" rel="noopener noreferrer" title="GitHub">
+                                <a class="social-github" href="https://github.com/taemincode" target="_blank" rel="noopener noreferrer" title="GitHub">
                                     <i class="fab fa-github"></i>
                                 </a>
-                                <a href="https://mail.google.com/mail/?view=cm&fs=1&to=welcome.taemin@gmail.com" target="_blank" rel="noopener noreferrer" title="Email">
+                                <a class="social-email" href="https://mail.google.com/mail/?view=cm&fs=1&to=welcome.taemin@gmail.com" target="_blank" rel="noopener noreferrer" title="Email">
                                     <i class="fas fa-envelope"></i>
                                 </a>
-                                <a href="https://www.youtube.com/@TaeminP" target="_blank" rel="noopener noreferrer" title="YouTube">
+                                <a class="social-youtube" href="https://www.youtube.com/@TaeminP" target="_blank" rel="noopener noreferrer" title="YouTube">
                                     <i class="fab fa-youtube"></i>
+                                </a>
+                                <a class="social-discord" href="https://discord.com/users/1310135456570282048" target="_blank" rel="noopener noreferrer" title="Discord">
+                                    <i class="fab fa-discord"></i>
+                                </a>
+                                <a class="social-chess" href="https://www.chess.com/member/vakktmn" target="_blank" rel="noopener noreferrer" title="Chess.com">
+                                    <i class="fas fa-chess-pawn"></i>
                                 </a>
                             </div>
                         </div>


### PR DESCRIPTION
This pull request updates the social links section on the homepage to introduce brand-specific hover colors and add new social links. The changes improve the visual distinction of each social icon and expand the available contact options.

**Styling improvements:**

* Added brand-specific hover colors and text-shadows for each social link icon in the `.social-links` section of the stylesheet, making each icon visually distinct when hovered.

**Content updates:**

* Updated the `index.html` file to add new social links for Discord and Chess.com, and assigned specific classes to each social link for targeted styling.