### PR TITLE
Update hover effects for social links; adjust colors for dark mode

### DIFF
--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -37,8 +37,12 @@
 .social-links a { color:var(--color-text-faint); font-size:1.5rem; transition:color .3s ease, transform .3s ease, text-shadow .3s ease; }
 .social-links a:hover { transform:translateY(-3px) scale(1.07); }
 /* Brand-specific hover colors */
-.social-links a.social-github:hover { color:#ffffff; text-shadow:0 4px 18px rgba(255,255,255,0.45); }
-.social-links a.social-email:hover { color:#5865F2; text-shadow:0 4px 18px rgba(234,67,53,0.55); }
+.social-links a.social-github:hover { color:#000000; text-shadow:0 4px 18px rgba(0,0,0,0.45); }
+@media (prefers-color-scheme: dark){
+	:root:not([data-theme="light"]) .social-links a.social-github:hover { color:#ffffff; text-shadow:0 4px 18px rgba(255,255,255,0.45); }
+}
+:root[data-theme="dark"] .social-links a.social-github:hover { color:#ffffff; text-shadow:0 4px 18px rgba(255,255,255,0.45); }
+.social-links a.social-email:hover { color:#5865F2; text-shadow:0 4px 18px rgba(88,101,242,0.55); }
 .social-links a.social-youtube:hover { color:#ff0000; text-shadow:0 4px 20px rgba(255,0,0,0.55); }
 .social-links a.social-discord:hover { color:#5865F2; text-shadow:0 4px 18px rgba(88,101,242,0.55); }
 .social-links a.social-chess:hover { color:#7fa650; text-shadow:0 4px 18px rgba(127,166,80,0.55); } /* chess.com green */

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -36,14 +36,14 @@
 .markdown ul li::marker { color:var(--primary-color); }
 .markdown blockquote { margin-bottom:1.25rem; margin-top:0; padding:1rem 1.25rem 1rem 1.25rem; border-left:4px solid var(--primary-color); background:linear-gradient(135deg, rgba(59,130,246,0.15), rgba(59,130,246,0.05)); font-style:italic; color:var(--color-text-soft); border-radius:0 .75rem .75rem 0; }
 .markdown code { background:var(--color-code-bg); padding:.22rem .45rem; border-radius:6px; font-size:.85em; color:var(--color-text); box-shadow:0 0 0 1px var(--color-code-border), 0 2px 4px -2px rgba(0,0,0,0.4); font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace; }
-.markdown pre { background:var(--color-code-bg); padding:2.5rem 1.2rem 1.25rem; border-radius:0.95rem; overflow-x:auto; margin:2rem 0; position:relative; box-shadow:0 6px 24px -10px rgba(0,0,0,0.65); border:1px solid var(--color-code-border); font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace; }
+.markdown pre { background:var(--color-code-bg); padding:3rem 1.2rem 1.25rem; border-radius:0.95rem; overflow-x:visible; margin:2rem 0; position:relative; box-shadow:0 6px 24px -10px rgba(0,0,0,0.65); border:1px solid var(--color-code-border); font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace; }
 /* copy button */
 .markdown pre > .code-copy-btn { position:absolute !important; top:4px !important; right:6px !important; background:rgba(0,0,0,0.42); color:#fff; border:none; width:30px; height:26px; padding:0; font-size:.8rem; border-radius:6px; cursor:pointer; display:grid; place-items:center; line-height:1; backdrop-filter:blur(5px) saturate(140%); box-shadow:0 2px 5px -2px rgba(0,0,0,0.55); transition:background .25s ease, transform .25s ease, box-shadow .25s ease; z-index:20; }
 .markdown pre > .code-copy-btn .copy-icon { display:block; line-height:1; position:relative; top:0; font-size:1.2rem; }
 .markdown pre .code-copy-btn:hover { background:rgba(0,0,0,0.5); transform:translateY(-2px); box-shadow:0 6px 14px -6px rgba(0,0,0,0.6); }
 .markdown pre .code-copy-btn:active { transform:translateY(0); }
 .markdown pre .code-copy-btn:focus-visible { outline:2px solid var(--primary-color); outline-offset:2px; }
-.markdown pre > .code-copy-btn.copied { background:var(--primary-color); color:#fff!important; box-shadow:0 0 0 1px rgba(255,255,255,0.1), 0 4px 18px -4px rgba(59,130,246,0.7); animation:copy-pop .45s cubic-bezier(.5,1.6,.4,1); position:relative; }
+.markdown pre > .code-copy-btn.copied { background:var(--primary-color); color:#fff!important; box-shadow:0 0 0 1px rgba(255,255,255,0.1), 0 4px 18px -4px rgba(59,130,246,0.7); animation:copy-pop .45s cubic-bezier(.5,1.6,.4,1); position:absolute !important; top:4px !important; right:6px !important; }
 .markdown pre > .code-copy-btn.copied::after { content:""; position:absolute; left:4px; right:4px; bottom:3px; height:3px; background:rgba(255,255,255,0.55); border-radius:2px; transform:scaleX(0); transform-origin:left; animation:copy-progress 3s linear forwards; mix-blend-mode:overlay; }
 @keyframes copy-pop { 0% { transform:translateY(0) scale(.85); } 55% { transform:translateY(-2px) scale(1.08); } 100% { transform:translateY(0) scale(1); } }
 @keyframes copy-progress { to { transform:scaleX(1); } }
@@ -51,12 +51,17 @@
 :root[data-theme="light"] .markdown pre > .code-copy-btn { background:rgba(255,255,255,0.55); color:#111; }
 :root[data-theme="light"] .markdown pre > .code-copy-btn:hover { background:rgba(255,255,255,0.75); }
 :root[data-theme="light"] .markdown pre > .code-copy-btn.copied { background:var(--primary-color); color:#fff; }
+/* Light mode: moderate contrast for tab bar vs code area */
+@media (prefers-color-scheme: light){
+	.markdown pre::before { background:linear-gradient(180deg, rgba(0,0,0,0.06), rgba(0,0,0,0.02)); box-shadow:inset 0 -1px 0 rgba(0,0,0,0.12); }
+}
+:root[data-theme="light"] .markdown pre::before { background:linear-gradient(180deg, rgba(0,0,0,0.07), rgba(0,0,0,0.03)); box-shadow:inset 0 -1px 0 rgba(0,0,0,0.10); }
 /* decorative header bar with traffic lights */
 .markdown pre::before { content:""; position:absolute; top:0; left:0; right:0; height:34px; border-radius:0.95rem 0.95rem 0 0; background:linear-gradient(90deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02)); box-shadow:0 1px 0 rgba(255,255,255,0.05) inset; }
 .markdown pre::after { content:""; position:absolute; top:10px; left:14px; width:10px; height:10px; border-radius:50%; background:#ff5f56; box-shadow:18px 0 0 #ffbd2e, 36px 0 0 #27c93f; opacity:.85; }
 /* subtle grid pattern */
-.markdown pre code { background:none; padding:0; font-size:.9rem; line-height:1.55; position:relative; z-index:1; }
-.markdown pre code::before { content:""; position:absolute; inset:0; background-image:linear-gradient(var(--color-code-border) 1px, transparent 1px), linear-gradient(90deg, var(--color-code-border) 1px, transparent 1px); background-size:22px 22px; opacity:.06; pointer-events:none; }
+.markdown pre code { background:none; padding:0; font-size:.9rem; line-height:1.55; position:relative; z-index:1; display:block; overflow-x:auto; -webkit-overflow-scrolling:touch; min-width:100%; box-shadow:none; border-radius:0; }
+.markdown pre code::before { content:none; }
 .markdown img { max-width:100%; height:auto; border-radius:0.9rem; margin:1rem 0; box-shadow:0 6px 20px -8px rgba(0,0,0,0.65), 0 0 0 1px rgba(255,255,255,0.04); transition: transform .35s ease, box-shadow .35s ease; }
 .markdown img:hover { transform:translateY(-3px); box-shadow:0 10px 28px -10px rgba(0,0,0,0.8), 0 0 0 1px rgba(59,130,246,0.25); }
 .post-footer { max-width:1000px; margin:0 auto 4rem; padding:0 2rem; }


### PR DESCRIPTION
This pull request updates the styling for social links and code blocks, with a focus on improving theme support and usability. The main changes include enhanced dark/light mode handling for social link hover colors and significant improvements to the appearance and behavior of code blocks in markdown posts.

**Theme-specific social link improvements:**

* Updated `.social-links a.social-github:hover` to use black in light mode and white in dark mode, with appropriate text-shadow, ensuring better visibility and consistency across themes. (`_sass/_about.scss`)
* Adjusted `.social-links a.social-email:hover` to use a more accurate brand color and matching text-shadow. (`_sass/_about.scss`)

**Code block and markdown enhancements:**

* Increased padding and changed `overflow-x` for `.markdown pre` to improve code block appearance and allow content to overflow visibly, making long lines more accessible. (`_sass/_post.scss`)
* Refined the copy button for code blocks to always be absolutely positioned, ensuring consistent placement even after copying. (`_sass/_post.scss`)
* Improved code block header bar and tab bar appearance in light mode, and removed the subtle grid pattern from code blocks for a cleaner look. (`_sass/_post.scss`)
* Updated `.markdown pre code` to be more responsive, with horizontal scrolling and minimum width, and removed unnecessary pseudo-element backgrounds. (`_sass/_post.scss`)