### PR TITLE
Post image zoom

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -204,6 +204,49 @@
                     }
                 });
             });
+
+            // Image lightbox for post pages
+            (function(){
+                var postContent = document.querySelector('.post-content');
+                if(!postContent) return; // only on post pages
+
+                var overlay = document.createElement('div');
+                overlay.className = 'post-lightbox';
+                overlay.setAttribute('role','dialog');
+                overlay.setAttribute('aria-modal','true');
+                overlay.setAttribute('aria-label','Image viewer');
+                var fullImg = document.createElement('img');
+                overlay.appendChild(fullImg);
+                document.body.appendChild(overlay);
+
+                function openLightbox(src, alt){
+                    fullImg.src = src;
+                    fullImg.alt = alt || '';
+                    overlay.classList.add('active');
+                    document.body.style.overflow = 'hidden';
+                }
+                function closeLightbox(){
+                    overlay.classList.remove('active');
+                    document.body.style.overflow = '';
+                    fullImg.src = '';
+                }
+                overlay.addEventListener('click', closeLightbox);
+                document.addEventListener('keydown', function(e){
+                    if(e.key === 'Escape' && overlay.classList.contains('active')) closeLightbox();
+                });
+
+                postContent.addEventListener('click', function(e){
+                    var t = e.target;
+                    if(!(t && t.tagName === 'IMG')) return;
+                    // prefer linked href if wrapped in anchor, else use image src
+                    var link = t.closest ? t.closest('a') : null;
+                    var candidate = (link && link.getAttribute('href')) ? link.getAttribute('href') : (t.currentSrc || t.src);
+                    if(candidate){
+                        e.preventDefault();
+                        openLightbox(candidate, t.alt);
+                    }
+                });
+            })();
         });
     </script>
 </body>

--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -11,7 +11,7 @@
 	:root:not([data-theme="light"]) .hero-photo:hover { filter:drop-shadow(0 0 6px rgba(59,130,246,0.6)) drop-shadow(0 0 18px rgba(59,130,246,0.4)); }
 }
 :root[data-theme="dark"] .hero-photo:hover { filter:drop-shadow(0 0 6px rgba(59,130,246,0.6)) drop-shadow(0 0 18px rgba(59,130,246,0.4)); }
-.hero-image { width:100%; height:100%; object-fit:cover; }
+.hero-image { width:100%; height:100%; object-fit:cover; user-select:none; }
 .hero-title { font-size:3.5rem; margin-bottom:1rem; color:var(--color-text); transition:text-shadow .45s ease, color .4s ease; cursor:default; user-select:none; }
 @media (prefers-color-scheme: dark){
 		:root:not([data-theme="light"]) .hero-title:hover { color:var(--primary-color); text-shadow:0 0 6px rgba(59,130,246,0.7), 0 0 14px rgba(59,130,246,0.4); }
@@ -27,7 +27,6 @@
 .snapshot-container { max-width:1200px; margin:0 auto; }
 .snapshot-card { background:var(--color-surface-alt); border-radius:1rem; box-shadow:0 6px 22px -8px rgba(0,0,0,0.55); padding:2rem; position:relative; overflow:hidden; transition: background .4s ease, box-shadow .4s ease, transform .4s ease; }
 .snapshot-card::before { content:''; position:absolute; inset:0; background:radial-gradient(circle at 85% 15%, rgba(59,130,246,0.18), transparent 70%); opacity:0; transition:opacity .6s ease; pointer-events:none; }
-.snapshot-card, .snapshot-card .profile-info, .snapshot-card .info-item, .snapshot-card .info-item span, .snapshot-card .info-item i, .snapshot-card .tech-stack, .snapshot-card .now-items, .snapshot-card .now-item, .snapshot-card .now-content, .snapshot-card .now-content h4, .snapshot-card .now-content p { cursor:default; user-select:none; -webkit-user-select:none; }
 .snapshot-card:hover { transform:translateY(-4px); box-shadow:0 12px 34px -12px rgba(0,0,0,0.7); }
 .snapshot-card:hover::before { opacity:1; }
 .snapshot-grid { display:flex; gap:2rem; }
@@ -95,7 +94,6 @@
 .story-section { padding:4rem 2rem; }
 .story-content { max-width:800px; margin:0 auto; }
 .story-text { line-height:1.75; font-size:1.05rem; }
-.story-section, .story-content, .story-text, .story-text p { cursor:default; }
 .story-text a[href^="http"] { position:relative; display:inline-block; color:var(--primary-color); text-decoration:none; padding-right:0; transition:color .25s ease; }
 /* underline spans full text width now */
 .story-text a[href^="http"]::before { content:""; position:absolute; left:0; right:0; height:2px; bottom:.08em; background:currentColor; transform:scaleX(0); transform-origin:left center; opacity:.55; transition:transform .4s ease, opacity .3s ease; border-radius:2px; }

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -78,12 +78,18 @@
 @media (max-width:768px){
 	.post-hero { padding:7.2rem 1rem 3rem; }
 	.post-container { padding:2rem 1rem; }
-	.post-content { padding:1.5rem; }
+	/* tighten top spacing inside the post card on mobile */
+	.post-content { padding:.75rem 1rem 1.25rem; }
+	/* avoid large initial jump caused by first element margins */
+	.post-content > :first-child { margin-top:1rem; }
 	.markdown { font-size:1rem; }
 	.markdown h1 { font-size:2rem; }
 	.markdown h2 { font-size:1.75rem; }
 	.markdown h3 { font-size:1.4rem; }
 	.post-nav { flex-direction:column; gap:1rem; }
+	/* show Next post first on mobile */
+	.post-nav-link.next { order:0; }
+	.post-nav-link.prev { order:1; }
 	.post-nav-link { text-align:center!important; width:100%; margin:0; border-radius:1rem; }
 	.post-footer { padding:0 1rem; }
 }

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -65,6 +65,8 @@
 .markdown pre code { background:none; padding:0; font-size:.9rem; line-height:1.55; position:relative; z-index:1; display:block; overflow-x:auto; -webkit-overflow-scrolling:touch; min-width:100%; box-shadow:none; border-radius:0; }
 .markdown pre code::before { content:none; }
 .markdown img { max-width:100%; height:auto; border-radius:0.9rem; margin:1rem 0; box-shadow:0 6px 20px -8px rgba(0,0,0,0.65), 0 0 0 1px rgba(255,255,255,0.04); transition: transform .35s ease, box-shadow .35s ease; }
+/* indicate images can be expanded */
+.markdown img { cursor: pointer; }
 .post-footer { max-width:1000px; margin:0 auto 4rem; padding:0 2rem; }
 .post-nav { display:flex; justify-content:space-between; gap:2rem; }
 .post-nav-link { flex:1; padding:1.5rem; background:var(--color-surface); border-radius:1rem; box-shadow:0 2px 10px -2px rgba(0,0,0,0.45); text-decoration:none; transition:transform .3s ease, box-shadow .3s ease, background .3s ease; position:relative; overflow:hidden; }
@@ -75,6 +77,10 @@
 .post-nav-link.next { text-align:right; }
 .post-nav-label { display:block; font-size:.9rem; color:var(--secondary-color); margin-bottom:.5rem; }
 .post-nav-title { display:block; font-size:1.1rem; color:var(--color-text); font-weight:500; }
+/* Lightbox overlay for post images */
+.post-lightbox { position:fixed; inset:0; padding:2rem; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,0.85); opacity:0; visibility:hidden; transition:opacity .25s ease, visibility .25s ease; z-index:2000; }
+.post-lightbox.active { opacity:1; visibility:visible; }
+.post-lightbox img { max-width:min(96vw, 1200px); max-height:90vh; border-radius:.75rem; box-shadow:0 10px 40px rgba(0,0,0,0.6); }
 @media (max-width:768px){
 	.post-hero { padding:7.2rem 1rem 3rem; }
 	.post-container { padding:2rem 1rem; }


### PR DESCRIPTION
This pull request introduces an image lightbox feature for post pages, allowing users to click on images to view them in an overlay. It also includes several style improvements to enhance user experience and accessibility across the site.

**Image Lightbox Feature:**

* Added JavaScript in `_layouts/default.html` to enable a lightbox overlay when images in `.post-content` are clicked, supporting keyboard navigation and accessibility attributes.
* Introduced corresponding CSS in `_sass/_post.scss` for the `.post-lightbox` overlay and its active state, ensuring images are displayed prominently and responsively.

**User Experience & Accessibility Enhancements:**

* Updated `.markdown img` in `_sass/_post.scss` to use a pointer cursor, visually indicating that images are clickable/expandable.
* Improved mobile layout for post content and navigation in `_sass/_post.scss`, including tighter spacing and reordering of navigation links for better usability on smaller screens.

**Minor Style Adjustments:**

* Added `user-select:none` to `.hero-image` in `_sass/_about.scss` to prevent accidental selection of hero images.
* Removed unnecessary `user-select` and `cursor` styles from several selectors in `_sass/_about.scss` for cleaner code. [[1]](diffhunk://#diff-a4bdfd8f6540c487f49bb4e12e9432e29f6085e021fc1d70388b17bb891a950eL30) [[2]](diffhunk://#diff-a4bdfd8f6540c487f49bb4e12e9432e29f6085e021fc1d70388b17bb891a950eL98)